### PR TITLE
make navbar not rounded

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -63,6 +63,12 @@ section.container {
 }
 
 
+/* Navbar */
+nav.navbar.navbar-default {
+    border-radius: 0;
+}
+
+
 /* Alerts */
 .alert-wrap {
     margin-top: -1px;


### PR DESCRIPTION
<img width="638" alt="2017-05-20 12 20 19" src="https://cloud.githubusercontent.com/assets/13472245/26254634/31bd10f2-3cf2-11e7-94fc-870c36e9a36c.png">
기존에 네비게이션 바 양 네 귀퉁이가 둥글었습니다. 이를 border-radius: 0; 을 적용하여 제거했습니다
