### PR TITLE
Update Django to 1.11.14 to prevent CSRF error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.5.3
 bs4==0.0.1
 click==6.7
-Django==1.11.1
+Django==1.11.14
 flake8==3.3.0
 flake8-commas==0.4.3
 flake8-import-order==0.12


### PR DESCRIPTION
It solves #205. I tested it locally and there's no breaking change.