### PR TITLE
NodeJS client: change ES6 syntax to CommonJS

### DIFF
--- a/client/sparcsssov2-node.js
+++ b/client/sparcsssov2-node.js
@@ -98,27 +98,32 @@ class Client {
     */
     const state = crypto.randomBytes(10).toString('hex');
     const params = {
-      clientId: this.clientId,
+      client_id: this.clientId,
       state,
     };
     const url = [this.URLS.token_require, Object.entries(params).map(e => e.join('=')).join('&')].join('?');
     return { url, state };
   }
 
-  getUserInfo(code) {
+  async getUserInfo(code) {
     /*
-      Exchange a code t;o user information
+      Exchange a code to user information
       :param code: the code that given by SPARCS SSO server
       :returns: a dictionary that contains user information
     */
     const { sign, timestamp } = this._signPayload([code]);
     const params = {
-      clientId: this.clientId,
+      client_id: this.clientId,
       code,
       timestamp,
       sign,
     };
-    return this._postData(this.URLS.token_info, params);
+    try {
+      const res = await Client._postData(this.URLS.token_info, params);
+      return res;
+    } catch (err) {
+      return err;
+    }
   }
 
   getLogoutUrl(sid, redirectUri) {
@@ -130,10 +135,10 @@ class Client {
     */
     const { sign, timestamp } = this._signPayload([sid, redirectUri]);
     const params = {
-      clientId: this.clientId,
+      client_id: this.clientId,
       sid,
       timestamp,
-      redirectUri,
+      redirect_uri: redirectUri,
       sign,
     };
     return [this.URLS.logout, Object.entries(params).map(e => e.join('=')).join('&')].join('?');
@@ -159,18 +164,18 @@ class Client {
     */
     const { sign, timestamp } = this._signPayload([sid, delta, message, lowerBound]);
     const params = {
-      clientId: this.clientId,
+      client_id: this.clientId,
       sid,
       delta,
       message,
-      lowerBound,
+      lower_bound: lowerBound,
       timestamp,
       sign,
     };
-    return this._postData(this.URLS.point, params);
+    return Client._postData(this.URLS.point, params);
   }
 
-  static async getNotice(offset = 0, limit = 3, date_after = 0) {
+  static async getNotice(offset = 0, limit = 3, dateAfter = 0) {
     /*
       Get some notices from SPARCS SSO
       :param offset: a offset to fetch from
@@ -181,7 +186,7 @@ class Client {
     const params = {
       offset,
       limit,
-      date_after,
+      date_after: dateAfter,
     };
     try {
       const res = await axios.get(this.URLS.notice, { params });

--- a/client/sparcsssov2-node.js
+++ b/client/sparcsssov2-node.js
@@ -20,7 +20,7 @@ const URLS = {
 SPARCS SSO V2 Client for NodeJS Version 0.1 (Unstable)
 Made by SPARCS SSO Team - appleseed
 
-Dependencies: node ^10.15.2, axios ^0.18.0
+Dependencies: node ^11.11.0, axios ^0.18.0
 */
 
 class Client {

--- a/client/sparcsssov2-node.js
+++ b/client/sparcsssov2-node.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const axios = require('axios');
+//const axios = require('axios');
 
 const SERVER_DOMAIN = 'https://sparcssso.kaist.ac.kr/';
 const BETA_DOMAIN = 'https://ssobeta.sparcs.org/';
@@ -23,7 +23,7 @@ Made by SPARCS SSO Team - appleseed
 Dependencies: node ^10.15.2, axios ^0.18.0
 */
 
-export default class Client {
+class Client {
   constructor(clientId, secretKey, isBeta = false, serverAddr = '') {
     /*
       Initialize SPARCS SSO Client
@@ -208,3 +208,5 @@ export default class Client {
     return sid;
   }
 }
+
+module.exports = Client;

--- a/client/sparcsssov2-node.js
+++ b/client/sparcsssov2-node.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-//const axios = require('axios');
+const axios = require('axios');
 
 const SERVER_DOMAIN = 'https://sparcssso.kaist.ac.kr/';
 const BETA_DOMAIN = 'https://ssobeta.sparcs.org/';


### PR DESCRIPTION
ES6 문법인 export default가 저번엔 transfile 없이 작동을 했었는데 (node 10.15.X) 지금 해보니 안되서 export 문만 수정했습니다. 저번 PR때 대체 왜 작동했는지 모르겠습니다..