### PR TITLE
API 테스팅 추가

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     install:
       - pip install -r requirements.txt
       - python manage.py migrate
+      - mkdir -p archive/buffer/
     script:
       - flake8 .
       - pytest tests/

--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -13,3 +13,10 @@ class NoticeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Notice
         fields = ['valid_from', 'valid_to', 'title', 'text']
+
+
+class TokenInfoQuerySerializer(serializers.Serializer):
+    client_id = serializers.CharField(required=True)
+    timestamp = serializers.CharField(required=True)
+    sign = serializers.CharField(required=True)
+    code = serializers.CharField(required=True)

--- a/apps/api/views/v2.py
+++ b/apps/api/views/v2.py
@@ -20,10 +20,11 @@ from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.api.serializers import NoticeFilterSerializer, NoticeSerializer
+from apps.api.serializers import NoticeFilterSerializer, NoticeSerializer, TokenInfoQuerySerializer
 from apps.core.backends import service_register, validate_email
 from apps.core.models import (
     AccessToken, Notice, PointLog, Service, ServiceMap, Statistic,
@@ -81,6 +82,7 @@ def check_sign(data, keys):
 
     sign = data.get('sign', '')
 
+    print(time.time(), timestamp)
     if abs(time.time() - timestamp) >= TIMEOUT:
         raise SuspiciousOperation(TokenFailReason.INVALID_TIMESTAMP)
 
@@ -96,9 +98,9 @@ def check_sign(data, keys):
 
 def build_suspicious_api_response(code: str, status_code: int = 400):
     # TODO: Add to log
-    return HttpResponse(json.dumps({
+    return Response({
         'code': code,
-    }, ensure_ascii=False), status=status_code)
+    }, status=status_code)
 
 
 @method_decorator(login_required, name='get')
@@ -135,7 +137,7 @@ class TokenRequireView(APIView):
             return render(request, 'api/denied.html', {
                 'reason': reason,
                 'alias': service.alias,
-            })
+            }, status=status.HTTP_403_FORBIDDEN)
 
         AccessToken.objects.filter(user=user, service=service).delete()
         m = ServiceMap.objects.filter(user=user, service=service).first()
@@ -181,9 +183,12 @@ class TokenRequireView(APIView):
 class TokenInfoView(APIView):
     # /token/info/
     @csrf_exempt
-    def post(self, request):
+    def post(self, request: Request):
+        req_body = TokenInfoQuerySerializer(data=request.data)
+        req_body.is_valid(raise_exception=True)
+        req_body = req_body.validated_data
         try:
-            service, [code], timestamp = check_sign(request.data, ['code'])
+            service, [code], timestamp = check_sign(req_body, ['code'])
         except SuspiciousOperation as exc:
             return build_suspicious_api_response(str(exc))
 

--- a/apps/api/views/v2.py
+++ b/apps/api/views/v2.py
@@ -82,7 +82,6 @@ def check_sign(data, keys):
 
     sign = data.get('sign', '')
 
-    print(time.time(), timestamp)
     if abs(time.time() - timestamp) >= TIMEOUT:
         raise SuspiciousOperation(TokenFailReason.INVALID_TIMESTAMP)
 

--- a/sparcssso/settings/common.py
+++ b/sparcssso/settings/common.py
@@ -93,6 +93,7 @@ RECAPTCHA_SECRET = os.environ.get('RECAPTCHA_SECRET', '')
 
 # E-mail settings
 EMAIL_HOST = 'localhost'
+EMAIL_PORT = 1025
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from rest_framework.test import APIClient
 
 from apps.core.models import SERVICE_TEST, Service, UserProfile
 
-
 KAIST_USER_INFO = '{"kaist_uid": "00111222", "mail": "jungnoh@kaist.ac.kr", "ku_sex": "M", "ku_acad_prog_code": "0",' \
                   '"ku_kaist_org_id": "1000", "ku_kname": "홍길", "ku_person_type": "Student",' \
                   '"ku_person_type_kor": "학생", "ku_psft_user_status_kor": "학", "ku_born_date": "2000-08-01",' \
@@ -89,6 +88,6 @@ class FixtureUserSet(object):
 
 class FixtureServiceSet(object):
     def __init__(self, admin: User):
-        self.test = ensure_service("test", "Test Service", admin, secret_key="SECRET__")
-        self.sparcs = ensure_service("sparcs", "SPARCS Service", admin, secret_key="SPARCS__")
-        self.public = ensure_service("public", "Public Service", admin, secret_key="PUBLIC__")
+        self.test = ensure_service("test", "Test Service", admin, secret_key="SECRET__", scope="TEST")
+        self.sparcs = ensure_service("sparcs", "SPARCS Service", admin, secret_key="SPARCS__", scope="SPARCS")
+        self.public = ensure_service("public", "Public Service", admin, secret_key="PUBLIC__", scope="PUBLIC")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ class FixtureUserSet(object):
         self.kaist = ensure_user(
             "kaist", ("KAIST", "user"), "jungnoh@kaist.ac.kr",
             kaist_id="jungnoh", kaist_info=KAIST_USER_INFO, kaist_info_time=datetime.datetime(2018, 10, 29, 12, 1, 0),
-            birthday=datetime.date(2000, 9, 1)
+            birthday=datetime.date(2000, 9, 1),
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,14 @@
+import hmac
 import re
 from datetime import timedelta
+from typing import Optional
 
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework import status
 from tests.conftest import FixtureServiceSet, FixtureUserSet, RequestSettingMixin
 
-from apps.core.models import AccessToken
+from apps.core.models import AccessToken, Service, ServiceMap
 
 
 class ApiTestCase(TestCase):
@@ -60,3 +62,63 @@ class TestTokenRequire(RequestSettingMixin, ApiTestCase):
         assert token.user == self.users.basic
         assert token.service == self.services.public
         assert token.expire_time < timezone.now() + timedelta(minutes=1)
+
+    def test_flags(self):
+        response = self.http_request(
+            self.users.admin, "get", "api/v2/token/require", querystring="client_id=public&state=12341234",
+        )
+        assert response.status_code == 403
+        response = self.http_request(
+            self.users.basic, "get", "api/v2/token/require", querystring="client_id=sparcs&state=12341234",
+        )
+        assert response.status_code == 403
+        response = self.http_request(
+            self.users.basic, "get", "api/v2/token/require", querystring="client_id=test&state=12341234",
+        )
+        assert response.status_code == 403
+        response = self.http_request(
+            self.users.test_only, "get", "api/v2/token/require", querystring="client_id=sparcs&state=12341234",
+        )
+        assert response.status_code == 403
+        response = self.http_request(
+            self.users.email_unauthed, "get", "api/v2/token/require", querystring="client_id=sparcs&state=12341234",
+        )
+        assert response.status_code == 403
+
+
+class TestTokenView(RequestSettingMixin, ApiTestCase):
+    def _send_request(self, service: Service, code: str, timestamp: int, mac: Optional[str] = None):
+        if not mac:
+            mac = hmac.new(service.secret_key.encode(), (code + str(timestamp)).encode()).hexdigest()
+        return self.http_request(None, "post", "api/v2/token/info", data={
+            "client_id": service.name,
+            "code": code,
+            "timestamp": str(timestamp),
+            "sign": mac,
+        })
+
+    def test_successful_flow(self):
+        for user in [self.users.basic, self.users.sparcs, self.users.kaist]:
+            response = self.http_request(
+                user, "get", "api/v2/token/require", querystring="client_id=public&state=12341234",
+            )
+            assert response.status_code == 302
+            redirect_url = response.url
+            url_matches = re.compile(r"\?code=([0-9a-f]+)&state=(.*)").findall(redirect_url)
+            response_code = url_matches[0][0]
+            response = self._send_request(self.services.public, response_code, int(timezone.now().timestamp()))
+
+            assert response.status_code == 200
+            assert response.data.get("uid") == user.username
+            service_map = ServiceMap.objects.get(user=user, service=self.services.public)
+            assert response.data.get("sid") == service_map.sid
+            assert response.data.get("email") == user.email
+            assert response.data.get("first_name") == user.first_name
+            assert response.data.get("last_name") == user.last_name
+            assert response.data.get("gender") == user.profile.gender
+            if user.profile.birthday is not None:
+                assert response.data.get("birthday") == user.profile.birthday.strftime("%Y-%m-%d")
+            assert response.data.get("kaist_id") == user.profile.kaist_id
+            if response.data.get("kaist_id") is not None:
+                assert response.data.get("kaist_info_time") == user.profile.kaist_info_time.strftime("%Y-%m-%d")
+            assert response.data.get("sparcs_id") == user.profile.sparcs_id

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,12 @@
+import re
+from datetime import timedelta
+
 from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
 from tests.conftest import FixtureServiceSet, FixtureUserSet, RequestSettingMixin
+
+from apps.core.models import AccessToken
 
 
 class ApiTestCase(TestCase):
@@ -13,10 +20,43 @@ class ApiTestCase(TestCase):
         super().tearDown()
 
 
-class ExampleTest(RequestSettingMixin, ApiTestCase):
-    def test_addition(self):
-        assert 1+1 == 2
+class TestTokenRequire(RequestSettingMixin, ApiTestCase):
+    def test_unauthorized_access(self):
+        response = self.http_request(None, "get", "api/v2/token/require")
+        assert response.status_code == status.HTTP_302_FOUND
 
-    def test_server(self):
-        response = self.http_request(None, "get", "")
-        assert response.status_code == 200
+    def test_bad_method(self):
+        response = self.http_request(None, "post", "api/v2/token/require")
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+        response = self.http_request(None, "put", "api/v2/token/require")
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+        response = self.http_request(None, "delete", "api/v2/token/require")
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_query_validation(self):
+        response = self.http_request(self.users.basic, "get", "api/v2/token/require")
+        assert response.status_code == 400
+
+        response = self.http_request(self.users.basic, "get", "api/v2/token/require", querystring="client_id=1029")
+        assert response.status_code == 400
+
+        response = self.http_request(self.users.basic, "get", "api/v2/token/require", querystring="state=1029")
+        assert response.status_code == 400
+
+    def test_successful_response(self):
+        response = self.http_request(
+            self.users.basic, "get", "api/v2/token/require", querystring="client_id=public&state=12341234",
+        )
+        assert response.status_code == 302
+        redirect_url = response.url
+        assert redirect_url.startswith(self.services.public.login_callback_url)
+
+        url_matches = re.compile(r"\?code=([0-9a-f]+)&state=(.*)").findall(redirect_url)
+        assert len(url_matches) == 1
+        response_code, response_state = url_matches[0]
+        assert response_state == "12341234"
+
+        token = AccessToken.objects.get(tokenid=response_code)
+        assert token.user == self.users.basic
+        assert token.service == self.services.public
+        assert token.expire_time < timezone.now() + timedelta(minutes=1)


### PR DESCRIPTION
테스트를 추가합니다.
API v2에 대한 커버리지가 충분히 높지는 않지만, 이번 PR에서 작업한 테스트만 잘 작동하면 향후 배포에서 치명적인 오류는 막을 수 있을것으로 판단하여 미리 머지합니다.

# 작업사항
- `/token/require` 테스팅
- `/token/info` 정상 응답 테스트 (각종 SuspciousOperation 테스트 필요)
- `/token/require` validation에 DRF serializer 사용

