### PR TITLE
Update Facebook OAuth to v10

### DIFF
--- a/apps/core/backends/auth.py
+++ b/apps/core/backends/auth.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import User
 
-from apps.core.backends.util import parse_gender
 from apps.core.models import UserProfile
 
 
@@ -103,7 +102,7 @@ def auth_fb_callback(code, callback_url):
         'code': code,
     }
     token_info = requests.get(
-        'https://graph.facebook.com/oauth/access_token?',
+        'https://graph.facebook.com/v10.0/oauth/access_token?',
         params=args, verify=True).json()
     if 'access_token' not in token_info:
         return None, None
@@ -113,26 +112,26 @@ def auth_fb_callback(code, callback_url):
     args = {
         'access_token': access_token,
     }
-    grant_info = requests.get('https://graph.facebook.com/v2.5/me/permissions',
+    grant_info = requests.get('https://graph.facebook.com/v10.0/me/permissions',
                               params=args, verify=True).json()
+
     for data in grant_info['data']:
         if data['status'] == 'declined':
             return None, None
 
     # get facebook profile
     args = {
-        'fields': 'email,first_name,last_name,gender,birthday',
+        'fields': 'email,first_name,last_name',
         'access_token': access_token,
     }
-    fb_info = requests.get('https://graph.facebook.com/v2.5/me',
+    fb_info = requests.get('https://graph.facebook.com/v10.0/me',
                            params=args, verify=True).json()
+
     info = {
         'userid': fb_info['id'],
         'email': fb_info.get('email'),
         'first_name': fb_info.get('first_name'),
         'last_name': fb_info.get('last_name'),
-        'gender': parse_gender(fb_info.get('gender')),
-        'birthday': fb_info.get('birthday'),
     }
     fb_profile = UserProfile.objects.filter(facebook_id=info['userid'],
                                             test_only=False).first()

--- a/apps/core/views/auth.py
+++ b/apps/core/views/auth.py
@@ -1,5 +1,5 @@
 import logging
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from django.conf import settings
 from django.contrib import auth
@@ -122,7 +122,7 @@ def init(request, mode, type):
         return redirect('/account/profile/')
 
     request.session['info_auth'] = {'mode': mode, 'type': type}
-    callback_url = request.build_absolute_uri('/account/callback/')
+    callback_url = urljoin(settings.DOMAIN, '/account/callback/')
 
     if type == 'FB':
         url = auth_fb_init(callback_url)
@@ -145,7 +145,7 @@ def callback(request):
     mode, type = auth['mode'], auth['type']
     if type == 'FB':
         code = request.GET.get('code')
-        callback_url = request.build_absolute_uri('/account/callback/')
+        callback_url = urljoin(settings.DOMAIN, '/account/callback/')
         profile, info = auth_fb_callback(code, callback_url)
     elif type == 'TW':
         tokens = request.session.get('request_token')


### PR DESCRIPTION
페이스북 로그인에서 사용하는 API를 v10으로 업데이트합니다.

`birthday`, `gender` 필드는 페이스북 측의 승인이 필요하도록 변경되었습니다. 앱 구동 영상이 필요하다고 하는데, SSO 특성상 통과되기 어려울 것 같아 아예 사용하지 않도록 변경했습니다. 승인을 받지 않으면 아예 API에서 값이 내려오지 않는 방식이기 때문에 오류는 발생하지 않았던것 같습니다.
이외에 API상의 breaking change는 없습니다.

이것때문에 프로덕션에서 페이스북 로그인이 작동하지 않는줄 알았는데, 또 잘 작동하네요 🤔